### PR TITLE
:bug: Fix feature importance plot

### DIFF
--- a/src/move/visualization/feature_importance.py
+++ b/src/move/visualization/feature_importance.py
@@ -169,6 +169,7 @@ def plot_continuous_feature_importance(
     palette = np.empty((25, 4))  # 25 colors x 4 channels
     palette[:13, :] = sm.to_rgba(np.linspace(vmin, 0, 13))  # first slope
     palette[12:, :] = sm.to_rgba(np.linspace(0, vmax, 13))  # second slope
+    palette = palette.tolist()  # NDArray not always supported
 
     with style_settings(style):
         fig, ax = plt.subplots(figsize=figsize)


### PR DESCRIPTION
Latest version of `seaborn` requires palettes to be lists of colors, does not support NumPy array.